### PR TITLE
Work

### DIFF
--- a/src/DsaCommon.hpp
+++ b/src/DsaCommon.hpp
@@ -12,7 +12,11 @@
 #ifndef _BASETSD_H_
 typedef unsigned char  BYTE;
 typedef unsigned short WORD;
+#ifdef _WIN32
 typedef unsigned long  DWORD;
+#else
+typedef unsigned int   DWORD;
+#endif
 typedef unsigned char  UINT8;
 typedef unsigned short UINT16;
 typedef unsigned int  UINT32;

--- a/src/device/emu2212.c
+++ b/src/device/emu2212.c
@@ -540,8 +540,9 @@ SCC_calc_stereo (SCC * scc, e_int16 buf[2]) {
           buf[0]+=b;
         else if(scc->ch_pan[i]==2) 
           buf[1]+=b;
-        else 
+        else {
           buf[0]+=b; buf[1]+=b;
+        }
       }
     }
   }


### PR DESCRIPTION
A fix for some compiler warnings, one probably harmless, the other having inpact on SCC panning.

Because of braces omitted, a `buf[1]+=b` statement is executed which is supposed to fill the right channel value, regardless of panning setting.